### PR TITLE
Fix recursion crash

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -12,6 +12,7 @@
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
+        "elm/browser": "1.0.2 <= v < 2.0.0",
         "elm/core": "1.0.0 <= v < 2.0.0",
         "elm/html": "1.0.0 <= v < 2.0.0",
         "elm/regex": "1.0.0 <= v < 2.0.0",

--- a/elm.json
+++ b/elm.json
@@ -12,13 +12,13 @@
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
-        "elm/browser": "1.0.2 <= v < 2.0.0",
         "elm/core": "1.0.0 <= v < 2.0.0",
         "elm/html": "1.0.0 <= v < 2.0.0",
         "elm/regex": "1.0.0 <= v < 2.0.0",
         "elm/url": "1.0.0 <= v < 2.0.0"
     },
     "test-dependencies": {
-        "elm-explorations/test": "2.2.0 <= v < 3.0.0"
+        "elm-explorations/test": "2.2.0 <= v < 3.0.0",
+        "elm/browser": "1.0.2 <= v < 2.0.0"
     }
 }

--- a/elm.json
+++ b/elm.json
@@ -19,6 +19,6 @@
         "elm/url": "1.0.0 <= v < 2.0.0"
     },
     "test-dependencies": {
-        "elm-explorations/test": "1.1.0 <= v < 2.0.0"
+        "elm-explorations/test": "2.2.0 <= v < 3.0.0"
     }
 }

--- a/src/Markdown/Block.elm
+++ b/src/Markdown/Block.elm
@@ -159,8 +159,11 @@ incorporateLines rawLines ast =
             ast
 
         rawLine :: rawLinesTail ->
-            incorporateLine rawLine ast
-                |> incorporateLines rawLinesTail
+            -- To get tail call optimization, use parentheses, not |> or <|.
+            -- Technically |> and <| are function calls.
+            -- If you use them, they will be in tail position, not the recursive call!
+            incorporateLines rawLinesTail
+                (incorporateLine rawLine ast)
 
 
 incorporateLine : String -> List (Block b i) -> List (Block b i)

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -1,6 +1,6 @@
 module Main exposing (..)
 
-import Browser exposing (Page)
+import Browser exposing (Document)
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (onInput)
@@ -11,12 +11,13 @@ import View
 
 main : Program () Model Msg
 main =
-    Browser.fullscreen
-        { init = \_ -> ( init, Cmd.none )
+    Browser.application
+        { init = \_ _ _ -> ( init, Cmd.none )
         , view = page
         , update = update
         , subscriptions = \_ -> Sub.none
-        , onNavigation = Nothing
+        , onUrlRequest = \_ -> NoOp
+        , onUrlChange = \_ -> NoOp
         }
 
 
@@ -36,7 +37,7 @@ init =
 type Msg
     = TextAreaInput String
     | TestMsg View.Msg
-
+    | NoOp
 
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
@@ -54,11 +55,15 @@ update msg model =
             , Cmd.none
             )
 
+        NoOp ->
+            ( model, Cmd.none )
 
-page : Model -> Page Msg
+
+page : Model -> Document Msg
 page model =
-    Page "Elm Markdown Tests" (view model)
-
+    { title = "Elm Markdown Tests"
+    , body = view model
+    }
 
 view : Model -> List (Html Msg)
 view model =

--- a/tests/Test/Inline/Custom.elm
+++ b/tests/Test/Inline/Custom.elm
@@ -52,6 +52,12 @@ run =
             , text "bazinga"
             ]
         ]
+    , testEq 1005
+        [ p [] [ text "Tail call optimization in block parsing" ] ]
+        ("Hello" ++ String.repeat 10000 "\n" ++ "World")
+        [ p [] [ text "Hello" ]
+        , p [] [ text "World" ]
+        ]
 
     -- TODO
     --, testEqDefaultOptions 1005


### PR DESCRIPTION
Thanks for this package! We are using it in our web application at NoRedInk.
Today we had a user who experienced a crash after entering 5000 newlines into a form! Our page crashed in `incorporateLines`.

Here's the offending Elm code. It is intended to be tail-recursive, so the compiled JS should have a `while` loop instead of actual recursion. But it doesn't!

```elm
incorporateLines : List String -> List (Block b i) -> List (Block b i)
incorporateLines rawLines ast =
    case rawLines of
        [] ->
            ast

        rawLine :: rawLinesTail ->
            incorporateLine rawLine ast
                |> incorporateLines rawLinesTail
```

```js
var $author$project$Markdown$Block$incorporateLines = F2(
	function (rawLines, ast) {
		if (!rawLines.b) {
			return ast;
		} else {
			var rawLine = rawLines.a;
			var rawLinesTail = rawLines.b;
			return A2(
				$author$project$Markdown$Block$incorporateLines,
				rawLinesTail,
				A2($author$project$Markdown$Block$incorporateLine, rawLine, ast));
		}
	});
```

The reason is that the `|>` is actually a function call! So technically the "tail" of this function is a call to `|>`, not a call to itself! So it does not count as tail recursive! This is not obvious at all.
When we change to parentheses, the compiler optimizes the tail call to a `while` loop as expected.

```elm
incorporateLines : List String -> List (Block b i) -> List (Block b i)
incorporateLines rawLines ast =
    case rawLines of
        [] ->
            ast

        rawLine :: rawLinesTail ->
            incorporateLines rawLinesTail
                (incorporateLine rawLine ast)
```
```js
var $author$project$Markdown$Block$incorporateLines = F2(
	function (rawLines, ast) {
		incorporateLines:
		while (true) {
			if (!rawLines.b) {
				return ast;
			} else {
				var rawLine = rawLines.a;
				var rawLinesTail = rawLines.b;
				var $temp$rawLines = rawLinesTail,
					$temp$ast = A2($author$project$Markdown$Block$incorporateLine, rawLine, ast);
				rawLines = $temp$rawLines;
				ast = $temp$ast;
				continue incorporateLines;
			}
		}
	});
```

I also did a few upgrades since this package seems to date back to when 0.19 was just a release candidate rather than a full release.